### PR TITLE
CentOS : Fix task lxc_container_create : Execute first script

### DIFF
--- a/vars/redhat-7.yml
+++ b/vars/redhat-7.yml
@@ -41,7 +41,6 @@ lxc_container_default_config_list:
 # image.
 _lxc_container_extra_commands: |
   which dnf &>/dev/null && RHT_PKG_MGR='dnf' || RHT_PKG_MGR='yum'
-  timeout 90 $RHT_PKG_MGR check-update
   echo "update" > /tmp/package-transaction.txt
   echo "install systemd-networkd systemd-resolved" >> /tmp/package-transaction.txt
   echo "run" >> /tmp/package-transaction.txt


### PR DESCRIPTION
Hi,

I encountered an error while running the first run script with CentOS.
yum check-update returns exit value of 100 if there are packages
available for an update therefore the task fails.

A check-update may not be necessary with yum ?